### PR TITLE
Update index.js

### DIFF
--- a/public/js/index.js
+++ b/public/js/index.js
@@ -111,7 +111,9 @@ console.log(localStorage.getItem('theme'))
 
 // Panic
 document.addEventListener('keydown', async (e) => {
-  if (localStorage.getItem('panickey') && localStorage.getItem('panickey') == e.key) window.parent.window.location.replace(localStorage.getItem('panicurl') || 'https://classroom.google.com/h')
-})
+  let panicurl = localStorage.getItem('panicurl'); 
+  panicurl = (panicurl && (!panicurl.includes("https://") && !panicurl.includes("http://"))) ? "https://"+panicurl : panicurl; 
+  if (localStorage.getItem('panickey') && localStorage.getItem('panickey') == e.key) window.parent.window.location.replace(panicurl || 'https://classroom.google.com/h');
+});
 
 // Debug


### PR DESCRIPTION
I figured this would be a nice addition, to someone who enters a url without the https:// part into the panic url box. This will prevent errors and any confusion by simply just adding it for them :). Without adding it, you goto an invalid url that looks like this "https://artclass.site/google.com".

Adds a check for when someone may enter just a url into the panic form that doesn't contain https://. If this happens it will add https:// to it and prevent the program from not working.